### PR TITLE
Add JSON5 import button to sidebar for user interaction reloading

### DIFF
--- a/src/viewer/sidebar.html
+++ b/src/viewer/sidebar.html
@@ -105,7 +105,9 @@
 		<h3 id="menu_scene"><span data-i18n="tb.scene_opt"></span></h3>
 		<div class="pv-menu-list">
 
-			<div id="scene_export"></div>
+			<div id="scene_import"></div>
+		<div id="scene_export"></div>
+		<input type="file" id="potree_import_file_input" accept=".json5" style="display: none;">
 
 			<div class="divider"><span>Objects</span></div>
 

--- a/src/viewer/sidebar.js
+++ b/src/viewer/sidebar.js
@@ -302,6 +302,49 @@ export class Sidebar{
 		
 
 		{
+			let elImport = elScene.next().find("#scene_import");
+			let potreeIcon = `${Potree.resourcePath}/icons/file_potree.svg`;
+			
+			elImport.append(`
+				Import: <br>
+				<img name="potree_import_button" src="${potreeIcon}" class="button-icon" style="height: 24px; cursor: pointer;" title="Import Potree JSON5 project file" />
+			`);
+
+			let elImportButton = elImport.find("img[name=potree_import_button]");
+			elImportButton.click(() => {
+				let fileInput = $("#potree_import_file_input");
+				fileInput.click();
+			});
+
+			let fileInput = $("#potree_import_file_input");
+			fileInput.on("change", async (event) => {
+				const file = event.target.files[0];
+				if (file && file.name.toLowerCase().endsWith(".json5")) {
+					try {
+						const text = await file.text();
+						const json = JSON5.parse(text);
+
+						if (json.type === "Potree") {
+							Potree.loadProject(this.viewer, json);
+							this.viewer.postMessage(`Project "${file.name}" loaded successfully.`);
+						} else {
+							this.viewer.postError("Invalid Potree project file format.");
+						}
+					} catch (e) {
+						console.error("Failed to parse the imported file as JSON5:");
+						console.error(e);
+						this.viewer.postError("Failed to parse the imported file. Please ensure it's a valid JSON5 file.");
+					}
+				} else {
+					this.viewer.postError("Please select a valid .json5 file.");
+				}
+				
+				// Reset the file input
+				event.target.value = '';
+			});
+		}
+
+		{
 			let elExport = elScene.next().find("#scene_export");
 
 			let geoJSONIcon = `${Potree.resourcePath}/icons/file_geojson.svg`;


### PR DESCRIPTION
Adds import functionality alongside existing export options in the Scene section:
- Import button with Potree icon for consistency with export UI
- Hidden file input accepting .json5 files only
- File validation and JSON5 parsing with error handling
- Integration with existing Potree.loadProject() function
- User feedback via success/error messages
- File input reset for repeated use

Addresses https://github.com/potree/potree/issues/595 by making the import feature discoverable through the UI, complementing the existing drag-and-drop functionality.


Please follow these instructions when creating a new pull request:

* Validating PRs can take a lot of time. The simpler the PR, the higher the chance that it will get accepted. 
* Set the potree develop branch as the PR target.
* Builds should not be part of the PR. Don't commit them. 
* Do not use a formatter. They make a mess out of diffs. 
* It takes a lot of time to download and test, as well as analyze the diffs,
so please excuse if it takes time to respond or if you don't get a response. 





