### PR TITLE
Implement inline editing for annotation titles and descriptions

### DIFF
--- a/src/Annotation.js
+++ b/src/Annotation.js
@@ -75,6 +75,15 @@ export class Annotation extends EventDispatcher {
 		};
 
 		this.elTitle.click(this.clickTitle);
+		this.elTitle.dblclick((e) => {
+			e.stopPropagation();
+			this.startEditingTitle();
+		});
+		
+		this.elDescription.find('.annotation-description-content').dblclick((e) => {
+			e.stopPropagation();
+			this.startEditingDescription();
+		});
 
 		this.actions = this.actions.map(a => {
 			if (a instanceof Action) {
@@ -560,6 +569,87 @@ export class Annotation extends EventDispatcher {
 			}
 		}
 	};
+
+	startEditingTitle() {
+		if (this.elTitle.find('input').length > 0) {
+			return; // Already editing
+		}
+
+		const currentTitle = this._title;
+		const input = $(`<input type="text" class="annotation-title-edit" value="${currentTitle}">`);
+		
+		this.elTitle.empty().append(input);
+		this.domElement.addClass('annotation-editing');
+		
+		input.focus().select();
+		
+		const finishEditing = (save = true) => {
+			if (save) {
+				const newTitle = input.val().trim();
+				if (newTitle !== currentTitle) {
+					this.title = newTitle || 'Untitled';
+				}
+			}
+			this.elTitle.empty().append(this._title);
+			this.domElement.removeClass('annotation-editing');
+		};
+		
+		input.on('blur', () => finishEditing(true));
+		input.on('keydown', (e) => {
+			if (e.key === 'Enter') {
+				e.preventDefault();
+				finishEditing(true);
+			} else if (e.key === 'Escape') {
+				e.preventDefault();
+				finishEditing(false);
+			}
+		});
+	}
+
+	startEditingDescription() {
+		const descriptionContent = this.elDescription.find('.annotation-description-content');
+		if (descriptionContent.find('textarea').length > 0) {
+			return; // Already editing
+		}
+
+		const currentDescription = this._description;
+		const textarea = $(`<textarea class="annotation-description-edit">${currentDescription}</textarea>`);
+		
+		descriptionContent.empty().append(textarea);
+		this.domElement.addClass('annotation-editing');
+		
+		textarea.focus().select();
+		
+		// Auto-resize textarea to content
+		const autoResize = () => {
+			textarea[0].style.height = 'auto';
+			textarea[0].style.height = Math.min(textarea[0].scrollHeight, 200) + 'px';
+		};
+		autoResize();
+		textarea.on('input', autoResize);
+		
+		const finishEditing = (save = true) => {
+			if (save) {
+				const newDescription = textarea.val().trim();
+				if (newDescription !== currentDescription) {
+					this.description = newDescription;
+				}
+			}
+			descriptionContent.empty().append(this._description);
+			this.domElement.removeClass('annotation-editing');
+		};
+		
+		textarea.on('blur', () => finishEditing(true));
+		textarea.on('keydown', (e) => {
+			if (e.key === 'Enter' && e.ctrlKey) {
+				e.preventDefault();
+				finishEditing(true);
+			} else if (e.key === 'Escape') {
+				e.preventDefault();
+				finishEditing(false);
+			}
+		});
+	}
 
 	dispose () {
 		if (this.domElement.parentElement) {

--- a/src/viewer/PropertyPanels/AnnotationPanel.js
+++ b/src/viewer/PropertyPanels/AnnotationPanel.js
@@ -72,6 +72,9 @@ export class AnnotationPanel{
 			annotation.description = description;
 		}, false);
 
+		// Listen for changes from the map annotation editing
+		annotation.addEventListener("annotation_changed", this._update);
+
 		this.update();
 	}
 
@@ -87,5 +90,11 @@ export class AnnotationPanel{
 		elDescription.html(annotation.description);
 
 
+	}
+
+	dispose(){
+		if(this.annotation && this._update){
+			this.annotation.removeEventListener("annotation_changed", this._update);
+		}
 	}
 };

--- a/src/viewer/potree.css
+++ b/src/viewer/potree.css
@@ -301,6 +301,44 @@ a:hover, a:visited, a:link, a:active{
 	color:			white;
 }
 
+.annotation-title-edit,
+.annotation-description-edit{
+	background-color:	rgba(255, 255, 255, 0.1);
+	border:			1px solid rgba(255, 255, 255, 0.5);
+	border-radius:		2px;
+	color:			white;
+	font-family:		Arial;
+	font-weight:		bold;
+	font-size:		inherit;
+	padding:		2px 4px;
+	outline:		none;
+	width:			100%;
+	box-sizing:		border-box;
+}
+
+.annotation-title-edit{
+	height:			1.5em;
+	line-height:		1.5em;
+	white-space:		nowrap;
+}
+
+.annotation-description-edit{
+	resize:			vertical;
+	min-height:		1.5em;
+	max-height:		200px;
+}
+
+.annotation-title-edit:focus,
+.annotation-description-edit:focus{
+	background-color:	rgba(255, 255, 255, 0.2);
+	border-color:		rgba(255, 255, 255, 0.8);
+}
+
+.annotation-editing .annotation-label,
+.annotation-editing .annotation-description-content{
+	cursor:			text;
+}
+
 .annotation-icon{
 	width:		20px;
 	height:		20px;


### PR DESCRIPTION
- Add double-click handlers to enable inline editing on map annotations
- Create dynamic input/textarea elements with proper styling
- Handle save/cancel operations with keyboard shortcuts (Enter/Escape)
- Add CSS classes for edit mode visual feedback
- Implement sidebar synchronization via annotation_changed events
- Support auto-resize for description textarea
- Maintain backward compatibility with existing sidebar editing

Features:
- Double-click title or description to edit inline
- Enter saves changes, Escape cancels
- Click outside saves automatically
- Changes sync with sidebar panel in real-time

Fixes #2


Please follow these instructions when creating a new pull request:

* Validating PRs can take a lot of time. The simpler the PR, the higher the chance that it will get accepted. 
* Set the potree develop branch as the PR target.
* Builds should not be part of the PR. Don't commit them. 
* Do not use a formatter. They make a mess out of diffs. 
* It takes a lot of time to download and test, as well as analyze the diffs,
so please excuse if it takes time to respond or if you don't get a response. 





